### PR TITLE
Fixes: Containers, Installation docs, numpy deprecation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM continuumio/miniconda3:latest
+
+ENV CONDA_ENV_NAME=verifyber
+
+WORKDIR /app 
+
+RUN conda create -y -n $CONDA_ENV_NAME python=3.8 \
+    && conda install -y -n $CONDA_ENV_NAME pytorch==1.12.1 torchvision==0.13.1 cudatoolkit=11.3 -c pytorch \
+    && conda install -y -n $CONDA_ENV_NAME pyg=*=*cu* -c pyg \
+    && conda install -y -n $CONDA_ENV_NAME mrtrix3=3.0 -c mrtrix3 \
+    && conda clean -afy
+
+# Activate the environment by default
+SHELL ["conda", "run", "-n", "verifyber", "/bin/bash", "-c"]
+
+# Additional dependencies
+RUN pip install antspyx==0.4.2 dipy==1.7.0 torchviz numba tensorboard
+RUN conda install pytorch-cluster -c pyg
+
+# Copy the project files
+COPY . .
+
+# Setup the configuration file. This is meant to be
+# overridden by the user at runtime, by mounting its
+# configuration file at runtime.
+ARG CONFIG_PATH=/app/run_config_file.json
+COPY run_config.json ${CONFIG_PATH}
+
+# User can simply mount this path to the appropriate configuration file on the host machine.
+ENV VERIFYBER_DEFAULT_CONFIG=${CONFIG_PATH}
+
+ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "verifyber", "python", "tractogram_filtering.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,6 @@ COPY run_config.json ${CONFIG_PATH}
 
 # User can simply mount this path to the appropriate configuration file on the host machine.
 ENV VERIFYBER_DEFAULT_CONFIG=${CONFIG_PATH}
+ENV VERIFYBER_OUTPUT_DIR=/app/output
 
 ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "verifyber", "python", "tractogram_filtering.py"]

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ The output are two text files containing the indexes of plausible and non-plausi
 - `model`: defalut = "sdec_extractor", choices are the names of the folder present in checkpoints/
 
 ## Usage
-1. setup your env follwing instructions in [verifyber_updated_env.txt](verifyber_updated_env.txt)
-2. run `tractogram_filtering.py -config <run_config.json>`
+1. Setup your env follwing instructions in [verifyber_updated_env.txt](verifyber_updated_env.txt)
+2. Run `tractogram_filtering.py -config <run_config.json>`
 
 ## Docker containers 
-See docker://pietroastolfi/tractogram-filtering:<tag>, <tag>=cpu|gpu. Note that the gpu container works with CUDA 10
+1. Install the NVIDIA container toolkit (so the containers can have access to the GPU): https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#
+2. (Optional) Build the container: `docker build -t mrzarfir/verifyber .`
+3. Run the container: `sudo ./verifyber <config_file | json> <output_dir> [<container_name (default mrzarfir/verifyber)>]`

--- a/datasets/basic_tract.py
+++ b/datasets/basic_tract.py
@@ -36,7 +36,7 @@ class TractDataset(gDataset):
 
             self.L_mem = L
             self.T_mem = np.array(np.split(T, L.cumsum()[:-1], axis=0),
-                             dtype=np.object)
+                             dtype=object)
 
     def __len__(self):
         return 1

--- a/tractogram_filtering.py
+++ b/tractogram_filtering.py
@@ -40,6 +40,8 @@ from utils.model_utils import get_model
 #     'cuda' if torch.cuda.is_available() else 'cpu')
 
 DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+VERIFYBER_DEFAULT_CONFIG = 'VERIFYBER_DEFAULT_CONFIG'
+VERIFYBER_OUTPUT_DIR = 'VERIFYBER_OUTPUT_DIR'
 
 SEED = 10
 
@@ -238,7 +240,7 @@ def get_sample(data):
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
-    default_config=os.getenv("VERIFYBER_DEFAULT_CONFIG", f'{script_dir}/run_config.json')
+    default_config=os.getenv(VERIFYBER_DEFAULT_CONFIG, f'{script_dir}/run_config.json')
     parser.add_argument('-config',
                         nargs='?',
                         default=default_config,
@@ -410,7 +412,12 @@ if __name__ == '__main__':
             prog_bar.close()
 
         ## save predictions
-        out_dir = f'{tmp_dir}/output'
+        out_dir = os.getenv(VERIFYBER_OUTPUT_DIR)
+        if out_dir is not None:
+            print(f'output directory set to {out_dir} (from env var {VERIFYBER_OUTPUT_DIR})')
+        else:
+            out_dir = f'{tmp_dir}/output'
+        
         if not osp.exists(out_dir):
             os.makedirs(out_dir)
 

--- a/tractogram_filtering.py
+++ b/tractogram_filtering.py
@@ -50,10 +50,13 @@ rs = np.random.RandomState(SEED)
 torch.manual_seed(SEED)
 torch.cuda.manual_seed(SEED)
 torch.backends.cudnn.benchmark = False
-try:
-    torch.use_deterministic_algorithms(True)
-except:
-    torch.backends.cudnn.deterministic = True
+# There are some operations that are not deterministic in this Pytorch version.
+# Uncommenting this might result in a crash. Commenting it out for now, as reproducibility
+# is not critical.
+# try:
+#     torch.use_deterministic_algorithms(True)
+# except:
+#     torch.backends.cudnn.deterministic = True
 os.environ['CUBLAS_WORKSPACE_CONFIG'] = ':4096:8' # see https://docs.nvidia.com/cuda/cublas/index.html#cublasApi_reproducibility
 
 
@@ -235,9 +238,10 @@ def get_sample(data):
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
+    default_config=os.getenv("VERIFYBER_DEFAULT_CONFIG", f'{script_dir}/run_config.json')
     parser.add_argument('-config',
                         nargs='?',
-                        default=f'{script_dir}/run_config.json',
+                        default=default_config,
                         help='The tag for the configuration file.')
     args = parser.parse_args()
 
@@ -422,7 +426,7 @@ if __name__ == '__main__':
                 hdr = nib.streamlines.load(cfg['trk'], lazy_load=True).header
                 streams, lengths = load_streamlines_fast(cfg['trk'], container='array_flat')
                 streamlines = np.split(streams, np.cumsum(lengths[:-1]))
-                streamlines = np.array(streamlines, dtype=np.object)[idxs_P]
+                streamlines = np.array(streamlines, dtype=object)[idxs_P]
                 out_t = nib.streamlines.Tractogram(streamlines,
                                                    affine_to_rasmm=np.eye(4))
                 out_t_name = osbn(cfg['trk'])[:-4] + '_filtered.trk'

--- a/utils/data/selective_loader.py
+++ b/utils/data/selective_loader.py
@@ -270,4 +270,4 @@ def load_selected_streamlines_uniform_size_seq(trk_fn,
 def fast_load_streamlines(trk_fn):
     streams, lengths = load_selected_streamlines(trk_fn)
     streamlines = np.split(streams, np.cumsum(lengths[:-1]))
-    return np.array(streamlines, dtype=np.object)
+    return np.array(streamlines, dtype=object)

--- a/utils/data/selective_loader_numba.py
+++ b/utils/data/selective_loader_numba.py
@@ -164,7 +164,7 @@ def load_streamlines(trk_fn,
         lengths[:] = resample
 
     if container == 'array':
-        streamlines = np.array(streamlines, dtype=np.object)
+        streamlines = np.array(streamlines, dtype=object)
     elif container == 'ArraySequence':
         streamlines = nib.streamlines.ArraySequence(streamlines)
     elif container == 'list':

--- a/verifyber
+++ b/verifyber
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+config_file=$1
+out_dir=$2
+container_name=$3
+
+if [ -z ${config_file} ] || [ -z ${out_dir} ]; then
+    echo "Usage: $0 <config_file> <out_dir> [<container_name (default: mrzarfir/verifyber)]>]"
+	exit 1
+fi
+
+if [ ! -f ${config_file} ]; then
+	echo "Config file ${config_file} does not exist."
+	exit 1
+fi
+
+config_file=$(realpath ${config_file})
+out_dir=$(realpath ${out_dir})
+container_name=${container_name:-mrzarfir/verifyber}
+
+echo "=========================================="
+echo "Running Verifyber"
+echo " ↳ Container: ${container_name}"
+echo " ↳ Config file: ${config_file}"
+echo " ↳ Output directory: ${out_dir}"
+echo "========================================="
+
+# Make sure the output directory exists
+mkdir -p ${out_dir}
+
+docker run --gpus=all \
+	-v ${config_file}:/app/run_config_file.json \
+	-v ${out_dir}:/app/output \
+	-t ${container_name}
+
+echo "=========================================="
+echo "Done. Results are in:"
+echo " ↳ ${out_dir}"
+echo "========================================="

--- a/verifyber_updated_env.txt
+++ b/verifyber_updated_env.txt
@@ -1,6 +1,7 @@
 conda install pytorch==1.12.1 torchvision==0.13.1 cudatoolkit=11.3 -c pytorch
 conda install pyg=*=*cu* -c pyg
+conda install pytorch-cluster -c pyg
 conda install mrtrix3=3.0 -c mrtrix3
-pip install antspyx==0.3.4 dipy==1.5.0 torchviz 
+pip install antspyx==0.4.2 dipy==1.7.0 torchviz
 [optional] pip install numba tensorboard
 


### PR DESCRIPTION
As the title suggests, the documentation of the project wasn't up to date to be able to execute the work properly. I made myself a small Dockerfile that seemed to work properly without having to do to installation locally, which was problematic on my side. I am creating a PR in case that can be useful to other users of this project, let me know if you find those modifications relevant enough to be merged, and I am open to modifying anything upon request.

Major changes:
- Using `np.object` is deprecated: I changed it to `object` as indicated by the deprecation message.
- Installation procedure file points to versions that do not seem to exist anymore and the installation for torch-cluster was missing.
- Dockerfile to easily create the docker container.
- Convenience script to run the built docker container with documentation attached in the README.md.